### PR TITLE
Fix world loading on latest versions of SubworldLibrary

### DIFF
--- a/Content/Subworlds/MultiverseWorld.cs
+++ b/Content/Subworlds/MultiverseWorld.cs
@@ -36,11 +36,6 @@ namespace Multiverse2.Content.Subworlds
 
 		public override List<GenPass> Tasks => GeneratorLoader.Get(Gen.Generator.Type).GetPasses(Gen, Config);
 
-		public override void Load()
-		{
-			ModTypeLookup<Subworld>.Register(this);
-		}
-
 		public override void DrawMenu(GameTime gameTime)
 		{
 			if (WorldGenerator.CurrentGenerationProgress != null)


### PR DESCRIPTION
This fixes (or at least appears to fix) this mod when used with the latest version of SubworldLibrary. I *think* `Load` is no longer required, as `Subworld`'s [Register](https://github.com/jjohnsnaill/SubworldLibrary/blob/master/SubworldLibrary.cs#L805) method already performs the appropriate registration logic.